### PR TITLE
Added social.waverly.miniblog to lexicon

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.3",
   "main": "src/index.ts",
   "scripts": {
-    "codegen": "lex gen-api ./src/client ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",
+    "codegen": "lex gen-api ./src/client ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/* ../../lexicons/social/waverly/*",
     "build": "node ./build.js",
     "postbuild": "tsc --build tsconfig.build.json",
     "update-main-to-dist": "node ./update-pkg.js --update-main-to-dist",

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -6419,6 +6419,50 @@ export const schemaDict = {
       },
     },
   },
+  SocialWaverlyMiniblog: {
+    lexicon: 1,
+    id: 'social.waverly.miniblog',
+    defs: {
+      main: {
+        type: 'record',
+        key: 'tid',
+        record: {
+          type: 'object',
+          required: ['text', 'subject', 'createdAt'],
+          properties: {
+            text: {
+              type: 'string',
+              maxLength: 20000,
+              maxGraphemes: 10000,
+            },
+            facets: {
+              type: 'array',
+              items: {
+                type: 'ref',
+                ref: 'lex:app.bsky.richtext.facet',
+              },
+            },
+            subject: {
+              type: 'ref',
+              ref: 'lex:com.atproto.repo.strongRef',
+            },
+            langs: {
+              type: 'array',
+              maxLength: 3,
+              items: {
+                type: 'string',
+                format: 'language',
+              },
+            },
+            createdAt: {
+              type: 'string',
+              format: 'datetime',
+            },
+          },
+        },
+      },
+    },
+  },
 }
 export const schemas: LexiconDoc[] = Object.values(schemaDict) as LexiconDoc[]
 export const lexicons: Lexicons = new Lexicons(schemas)
@@ -6549,4 +6593,5 @@ export const ids = {
   AppBskyUnspeccedGetPopularFeedGenerators:
     'app.bsky.unspecced.getPopularFeedGenerators',
   AppBskyUnspeccedGetTimelineSkeleton: 'app.bsky.unspecced.getTimelineSkeleton',
+  SocialWaverlyMiniblog: 'social.waverly.miniblog',
 }

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -10,7 +10,7 @@
   "main": "src/index.ts",
   "bin": "dist/bin.ts",
   "scripts": {
-    "codegen": "lex gen-server ./src/lexicon ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",
+    "codegen": "lex gen-server ./src/lexicon ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/* ../../lexicons/social/waverly/*",
     "build": "node ./build.js",
     "postbuild": "tsc --build tsconfig.build.json",
     "start": "node dist/bin.js",

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -132,11 +132,13 @@ export class Server {
   xrpc: XrpcServer
   com: ComNS
   app: AppNS
+  social: SocialNS
 
   constructor(options?: XrpcOptions) {
     this.xrpc = createXrpcServer(schemas, options)
     this.com = new ComNS(this)
     this.app = new AppNS(this)
+    this.social = new SocialNS(this)
   }
 }
 
@@ -1066,6 +1068,24 @@ export class UnspeccedNS {
   ) {
     const nsid = 'app.bsky.unspecced.getTimelineSkeleton' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
+  }
+}
+
+export class SocialNS {
+  _server: Server
+  waverly: WaverlyNS
+
+  constructor(server: Server) {
+    this._server = server
+    this.waverly = new WaverlyNS(server)
+  }
+}
+
+export class WaverlyNS {
+  _server: Server
+
+  constructor(server: Server) {
+    this._server = server
   }
 }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -6419,6 +6419,50 @@ export const schemaDict = {
       },
     },
   },
+  SocialWaverlyMiniblog: {
+    lexicon: 1,
+    id: 'social.waverly.miniblog',
+    defs: {
+      main: {
+        type: 'record',
+        key: 'tid',
+        record: {
+          type: 'object',
+          required: ['text', 'subject', 'createdAt'],
+          properties: {
+            text: {
+              type: 'string',
+              maxLength: 20000,
+              maxGraphemes: 10000,
+            },
+            facets: {
+              type: 'array',
+              items: {
+                type: 'ref',
+                ref: 'lex:app.bsky.richtext.facet',
+              },
+            },
+            subject: {
+              type: 'ref',
+              ref: 'lex:com.atproto.repo.strongRef',
+            },
+            langs: {
+              type: 'array',
+              maxLength: 3,
+              items: {
+                type: 'string',
+                format: 'language',
+              },
+            },
+            createdAt: {
+              type: 'string',
+              format: 'datetime',
+            },
+          },
+        },
+      },
+    },
+  },
 }
 export const schemas: LexiconDoc[] = Object.values(schemaDict) as LexiconDoc[]
 export const lexicons: Lexicons = new Lexicons(schemas)
@@ -6549,4 +6593,5 @@ export const ids = {
   AppBskyUnspeccedGetPopularFeedGenerators:
     'app.bsky.unspecced.getPopularFeedGenerators',
   AppBskyUnspeccedGetTimelineSkeleton: 'app.bsky.unspecced.getTimelineSkeleton',
+  SocialWaverlyMiniblog: 'social.waverly.miniblog',
 }

--- a/packages/pds/src/lexicon/types/social/waverly/miniblog.ts
+++ b/packages/pds/src/lexicon/types/social/waverly/miniblog.ts
@@ -1,0 +1,31 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { lexicons } from '../../../lexicons'
+import { isObj, hasProp } from '../../../util'
+import { CID } from 'multiformats/cid'
+import * as AppBskyRichtextFacet from '../../app/bsky/richtext/facet'
+import * as ComAtprotoRepoStrongRef from '../../com/atproto/repo/strongRef'
+
+export interface Record {
+  text: string
+  facets?: AppBskyRichtextFacet.Main[]
+  subject: ComAtprotoRepoStrongRef.Main
+  langs?: string[]
+  createdAt: string
+  [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'social.waverly.miniblog#main' ||
+      v.$type === 'social.waverly.miniblog')
+  )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('social.waverly.miniblog#main', v)
+}


### PR DESCRIPTION
First addition to atproto: our own lexicon `social.waverly.miniblog`.

Most of that PR is codegen'd. Our manual changes are in:
- `lexicons/social/waverly/*`
- `packages/api/package.json`
- `packages/pds/package.json`