### PR TITLE
Added some missing files for lexicon

### DIFF
--- a/lexicons/social/waverly/miniblog.json
+++ b/lexicons/social/waverly/miniblog.json
@@ -1,0 +1,29 @@
+{
+    "lexicon": 1,
+    "id": "social.waverly.miniblog",
+    "defs": {
+      "main": {
+        "type": "record",
+        "key": "tid",
+        "record": {
+          "type": "object",
+          "required": ["text", "subject", "createdAt"],
+          "properties": {
+            "text": {"type": "string", "maxLength": 20000, "maxGraphemes": 10000},
+            "facets": {
+              "type": "array",
+              "items": {"type": "ref", "ref": "app.bsky.richtext.facet"}
+            },
+            "subject": {"type": "ref", "ref": "com.atproto.repo.strongRef"},
+            "langs": {
+              "type": "array",
+              "maxLength": 3,
+              "items": {"type": "string", "format": "language"}
+            },
+            "createdAt": {"type": "string", "format": "datetime"}
+          }
+        }
+      }
+    }
+  }
+  

--- a/packages/api/src/client/types/social/waverly/miniblog.ts
+++ b/packages/api/src/client/types/social/waverly/miniblog.ts
@@ -1,0 +1,31 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { isObj, hasProp } from '../../../util'
+import { lexicons } from '../../../lexicons'
+import { CID } from 'multiformats/cid'
+import * as AppBskyRichtextFacet from '../../app/bsky/richtext/facet'
+import * as ComAtprotoRepoStrongRef from '../../com/atproto/repo/strongRef'
+
+export interface Record {
+  text: string
+  facets?: AppBskyRichtextFacet.Main[]
+  subject: ComAtprotoRepoStrongRef.Main
+  langs?: string[]
+  createdAt: string
+  [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'social.waverly.miniblog#main' ||
+      v.$type === 'social.waverly.miniblog')
+  )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('social.waverly.miniblog#main', v)
+}


### PR DESCRIPTION
Previous PR was missing some files. Ooops.
This completes the lexicon for `social.waverly.miniblog`.