### PR TITLE
Added CRUD support for social.waverly.miniblog

### DIFF
--- a/lexicons/social/waverly/miniblog.json
+++ b/lexicons/social/waverly/miniblog.json
@@ -7,7 +7,7 @@
         "key": "tid",
         "record": {
           "type": "object",
-          "required": ["text", "subject", "createdAt"],
+          "required": ["text", "createdAt"],
           "properties": {
             "text": {"type": "string", "maxLength": 20000, "maxGraphemes": 10000},
             "facets": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -6428,7 +6428,7 @@ export const schemaDict = {
         key: 'tid',
         record: {
           type: 'object',
-          required: ['text', 'subject', 'createdAt'],
+          required: ['text', 'createdAt'],
           properties: {
             text: {
               type: 'string',

--- a/packages/api/src/client/types/social/waverly/miniblog.ts
+++ b/packages/api/src/client/types/social/waverly/miniblog.ts
@@ -11,7 +11,7 @@ import * as ComAtprotoRepoStrongRef from '../../com/atproto/repo/strongRef'
 export interface Record {
   text: string
   facets?: AppBskyRichtextFacet.Main[]
-  subject: ComAtprotoRepoStrongRef.Main
+  subject?: ComAtprotoRepoStrongRef.Main
   langs?: string[]
   createdAt: string
   [k: string]: unknown

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -6428,7 +6428,7 @@ export const schemaDict = {
         key: 'tid',
         record: {
           type: 'object',
-          required: ['text', 'subject', 'createdAt'],
+          required: ['text', 'createdAt'],
           properties: {
             text: {
               type: 'string',

--- a/packages/pds/src/lexicon/types/social/waverly/miniblog.ts
+++ b/packages/pds/src/lexicon/types/social/waverly/miniblog.ts
@@ -11,7 +11,7 @@ import * as ComAtprotoRepoStrongRef from '../../com/atproto/repo/strongRef'
 export interface Record {
   text: string
   facets?: AppBskyRichtextFacet.Main[]
-  subject: ComAtprotoRepoStrongRef.Main
+  subject?: ComAtprotoRepoStrongRef.Main
   langs?: string[]
   createdAt: string
   [k: string]: unknown

--- a/packages/pds/src/repo/prepare.ts
+++ b/packages/pds/src/repo/prepare.ts
@@ -179,6 +179,7 @@ const ALLOWED_PUTS = [
   lex.ids.AppBskyActorProfile,
   lex.ids.AppBskyGraphList,
   lex.ids.AppBskyFeedGenerator,
+  lex.ids.SocialWaverlyMiniblog,
 ]
 
 export const prepareUpdate = async (opts: {

--- a/packages/pds/src/services/record/index.ts
+++ b/packages/pds/src/services/record/index.ts
@@ -66,11 +66,14 @@ export class RecordService {
     }
     await this.addBacklinks(backlinks)
 
-    // Send to indexers
-    await this.messageDispatcher.send(
-      this.db,
-      indexRecord(uri, cid, obj, action, record.indexedAt),
-    )
+    // Skip external indexing for social.waverly objects
+    if (!uri.collection.startsWith('social.waverly.')) {
+      // Send to indexers
+      await this.messageDispatcher.send(
+        this.db,
+        indexRecord(uri, cid, obj, action, record.indexedAt),
+      )
+    }
 
     log.info({ uri }, 'indexed record')
   }
@@ -86,10 +89,14 @@ export class RecordService {
       .deleteFrom('backlink')
       .where('uri', '=', uri.toString())
       .execute()
-    await Promise.all([
-      this.messageDispatcher.send(this.db, deleteRecord(uri, cascading)),
-      deleteQuery,
-    ])
+
+    // Skip external indexing for social.waverly objects
+    if (!uri.collection.startsWith('social.waverly.')) {
+      await Promise.all([
+        this.messageDispatcher.send(this.db, deleteRecord(uri, cascading)),
+        deleteQuery,
+      ])
+    }
 
     log.info({ uri }, 'deleted indexed record')
   }

--- a/packages/pds/tests/crud.test.ts
+++ b/packages/pds/tests/crud.test.ts
@@ -454,7 +454,7 @@ describe('crud operations', () => {
       })
 
       await expect(edit).rejects.toThrow(
-        'Temporarily only accepting updates for collections: app.bsky.actor.profile, app.bsky.graph.list, app.bsky.feed.generator',
+        'Temporarily only accepting updates for collections: app.bsky.actor.profile, app.bsky.graph.list, app.bsky.feed.generator, social.waverly.miniblog',
       )
     })
 

--- a/packages/pds/tests/waverly.crud.test.ts
+++ b/packages/pds/tests/waverly.crud.test.ts
@@ -1,0 +1,190 @@
+import { AtUri } from '@atproto/uri'
+import AtpAgent from '@atproto/api'
+import { CloseFn, runTestServer } from './_util'
+import AppContext from '../src/context'
+import * as Miniblog from '../src/lexicon/types/social/waverly/miniblog'
+import { ids } from '../src/lexicon/lexicons'
+
+const loremIpsum =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vitae arcu ut nulla dictum sagittis. Integer viverra ullamcorper augue vitae gravida. Cras quis mauris ac eros iaculis aliquam. Aliquam sit amet quam vitae turpis vehicula pellentesque sed feugiat turpis. Nam interdum laoreet pulvinar. Nulla eu blandit lectus. Sed quis tortor eget metus vulputate blandit sit amet nec erat. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse potenti.' +
+  'Praesent sed dui ac tellus congue aliquam vitae eu quam. Nullam vitae ante quis sem semper semper non ac diam. Ut porta justo quis interdum placerat. Aliquam efficitur bibendum leo non condimentum. Fusce ullamcorper ultricies nunc ut ornare. Duis interdum vehicula risus, sit amet porta nunc facilisis ac. Nulla facilisi. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas molestie justo sed arcu facilisis, et accumsan neque placerat. Ut fringilla vehicula magna, ac pellentesque neque pretium vel.' +
+  'Nulla facilisi. Aenean auctor dignissim neque, dapibus vulputate dui semper euismod. Integer ut turpis at urna congue suscipit. Nulla facilisi. Ut sit amet malesuada orci. Aliquam id tellus vel diam luctus pulvinar vel eget felis. Aliquam erat volutpat. Phasellus semper nibh mi, quis laoreet est blandit sit amet. Nulla facilisi. Vivamus semper sem et ligula tincidunt, nec lacinia ex maximus.' +
+  'Nunc fringilla gravida diam, ac sollicitudin lacus pharetra id. Fusce imperdiet turpis mauris, eu laoreet enim vulputate luctus. Nulla eu pharetra risus, a dapibus libero. Vestibulum auctor turpis sem, a accumsan metus venenatis at. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Vivamus lorem erat, aliquam ac placerat eget, dapibus id urna. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Donec hendrerit magna vel lacus varius, a consequat neque tempor. Vestibulum rutrum elit nec enim pretium, sed viverra felis molestie. Nunc a urna in nibh molestie tempor nec eget ex. Curabitur condimentum erat libero, quis porta odio malesuada vitae. Integer vulputate purus sed quam convallis, in egestas quam ultricies. Integer interdum posuere elit a tempus. Proin interdum porta viverra. Maecenas condimentum fermentum euismod. Curabitur arcu purus, pellentesque tempor tellus at, dictum faucibus felis.' +
+  'Nunc ultricies fermentum faucibus. Nunc ac urna congue mi tristique pharetra at eu eros. Donec ipsum velit, lobortis vel nisl ac, laoreet iaculis tellus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus molestie ipsum tincidunt pulvinar interdum. Aliquam erat volutpat. Cras tempus leo risus, tempus lobortis ex pellentesque et. Etiam convallis lorem elit, eget aliquam dui rhoncus sit amet. In quis euismod elit. Sed ut elit a diam elementum varius semper imperdiet quam. Donec ut hendrerit magna. Mauris ac feugiat urna, ac fermentum felis. Donec nec blandit augue. Pellentesque hendrerit, lorem eget accumsan aliquam, velit turpis laoreet dolor, sit amet cursus enim purus sit amet lectus. Mauris nec tortor turpis.'
+
+const alice = {
+  email: 'alice@test.com',
+  handle: 'alice.test',
+  did: '',
+  password: 'alice-pass',
+}
+
+describe('waverly crud operations', () => {
+  let ctx: AppContext
+  let agent: AtpAgent
+  let aliceAgent: AtpAgent
+  let bobAgent: AtpAgent
+  let close: CloseFn
+
+  beforeAll(async () => {
+    const server = await runTestServer({
+      dbPostgresSchema: 'waverly_crud',
+    })
+    ctx = server.ctx
+    close = server.close
+    agent = new AtpAgent({ service: server.url })
+    aliceAgent = new AtpAgent({ service: server.url })
+  })
+
+  afterAll(async () => {
+    await close()
+  })
+
+  it('registers users', async () => {
+    const res = await agent.api.com.atproto.server.createAccount({
+      email: alice.email,
+      handle: alice.handle,
+      password: alice.password,
+    })
+    aliceAgent.api.setHeader('authorization', `Bearer ${res.data.accessJwt}`)
+    alice.did = res.data.did
+  })
+
+  let uri1: AtUri
+  let subjectUri1: AtUri
+  it('creates records', async () => {
+    const res1 = await aliceAgent.api.com.atproto.repo.createRecord({
+      repo: alice.did,
+      collection: ids.AppBskyFeedPost,
+      record: {
+        $type: ids.AppBskyFeedPost,
+        text: 'This is the bluesky post for the miniblog',
+        createdAt: new Date().toISOString(),
+      },
+    })
+    subjectUri1 = new AtUri(res1.data.uri)
+    const res2 = await aliceAgent.api.com.atproto.repo.createRecord({
+      repo: alice.did,
+      collection: ids.SocialWaverlyMiniblog,
+      record: {
+        $type: ids.SocialWaverlyMiniblog,
+        text: loremIpsum,
+        subject: {
+          uri: res1.data.uri.toString(),
+          cid: res1.data.cid.toString(),
+        },
+        createdAt: new Date().toISOString(),
+      },
+    })
+    uri1 = new AtUri(res2.data.uri)
+    expect(res2.data.uri).toBe(
+      `at://${alice.did}/social.waverly.miniblog/${uri1.rkey}`,
+    )
+  })
+
+  it('lists records', async () => {
+    const res = await agent.api.com.atproto.repo.listRecords({
+      repo: alice.did,
+      collection: ids.SocialWaverlyMiniblog,
+    })
+    expect(res.data.records.length).toBe(1)
+    expect(res.data.records[0].uri).toBe(uri1.toString())
+    const value = res.data.records[0].value as Miniblog.Record
+    expect(value.text).toBe(loremIpsum)
+    expect(value.subject?.uri).toBe(subjectUri1.toString())
+  })
+
+  it('gets records', async () => {
+    const res = await agent.api.com.atproto.repo.getRecord({
+      repo: alice.did,
+      collection: ids.SocialWaverlyMiniblog,
+      rkey: uri1.rkey,
+    })
+    expect(res.data.uri).toBe(uri1.toString())
+    const value = res.data.value as Miniblog.Record
+    expect(value.text).toBe(loremIpsum)
+    expect(value.subject?.uri).toBe(subjectUri1.toString())
+  })
+
+  let uri2: AtUri
+  it('creates records without subject', async () => {
+    const res1 = await aliceAgent.api.com.atproto.repo.createRecord({
+      repo: alice.did,
+      collection: ids.SocialWaverlyMiniblog,
+      record: {
+        $type: ids.SocialWaverlyMiniblog,
+        text: loremIpsum,
+        createdAt: new Date().toISOString(),
+      },
+    })
+    uri2 = new AtUri(res1.data.uri)
+    expect(res1.data.uri).toBe(
+      `at://${alice.did}/social.waverly.miniblog/${uri2.rkey}`,
+    )
+    const res2 = await agent.api.com.atproto.repo.getRecord({
+      repo: alice.did,
+      collection: ids.SocialWaverlyMiniblog,
+      rkey: uri2.rkey,
+    })
+    expect(res2.data.uri).toBe(uri2.toString())
+    const value = res2.data.value as Miniblog.Record
+    expect(value.text).toBe(loremIpsum)
+    expect(value.subject).toBeUndefined()
+  })
+
+  it('adds subjects to records', async () => {
+    const res1 = await aliceAgent.api.com.atproto.repo.createRecord({
+      repo: alice.did,
+      collection: ids.AppBskyFeedPost,
+      record: {
+        $type: ids.AppBskyFeedPost,
+        text: 'This is the bluesky post for the second miniblog',
+        createdAt: new Date().toISOString(),
+      },
+    })
+    const res2 = await agent.api.com.atproto.repo.getRecord({
+      repo: alice.did,
+      collection: ids.SocialWaverlyMiniblog,
+      rkey: uri2.rkey,
+    })
+    const record = res2.data.value as Miniblog.Record
+    record.subject = {
+      uri: res1.data.uri.toString(),
+      cid: res1.data.cid.toString(),
+    }
+    const res3 = await aliceAgent.api.com.atproto.repo.putRecord({
+      repo: alice.did,
+      collection: ids.SocialWaverlyMiniblog,
+      rkey: uri2.rkey,
+      record,
+    })
+    expect(res3.data.uri).toBe(uri2.toString())
+    const res4 = await agent.api.com.atproto.repo.getRecord({
+      repo: alice.did,
+      collection: ids.SocialWaverlyMiniblog,
+      rkey: uri2.rkey,
+    })
+    expect(res4.data.uri).toBe(uri2.toString())
+    const value = res4.data.value as Miniblog.Record
+    expect(value.text).toBe(loremIpsum)
+    expect(value.subject?.uri).toBe(res1.data.uri.toString())
+  })
+
+  it('deletes records', async () => {
+    await aliceAgent.api.com.atproto.repo.deleteRecord({
+      repo: alice.did,
+      collection: ids.SocialWaverlyMiniblog,
+      rkey: uri1.rkey,
+    })
+    await aliceAgent.api.com.atproto.repo.deleteRecord({
+      repo: alice.did,
+      collection: ids.SocialWaverlyMiniblog,
+      rkey: uri2.rkey,
+    })
+    const res1 = await agent.api.com.atproto.repo.listRecords({
+      repo: alice.did,
+      collection: ids.SocialWaverlyMiniblog,
+    })
+    expect(res1.data.records.length).toBe(0)
+  })
+})


### PR DESCRIPTION
Added support and tests for CRUD operations in the PDS for  `social.waverly.miniblog`.

Makes `subject` optional on `social.waverly.miniblog` so we can create the miniblog post before the bluesky post is created.
