### PR TITLE
Experiment number 2 with npm

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@atproto-waverly/api",
+  "name": "@waverlyai/atproto-api",
   "version": "0.4.3",
   "main": "src/index.ts",
   "scripts": {


### PR DESCRIPTION
Experiment number 2 to try to publish our own version of atproto to a public npm repo. Changed name to fit our scope:
`@waverlyai/atproto-api`.