### PR TITLE
Embed in bsky

### DIFF
--- a/lexicons/social/waverly/miniblog.json
+++ b/lexicons/social/waverly/miniblog.json
@@ -15,15 +15,6 @@
               "items": {"type": "ref", "ref": "app.bsky.richtext.facet"}
             },
             "subject": {"type": "ref", "ref": "com.atproto.repo.strongRef"},
-            "embed": {
-              "type": "union",
-              "refs": [
-                "app.bsky.embed.images",
-                "app.bsky.embed.external",
-                "app.bsky.embed.record",
-                "app.bsky.embed.recordWithMedia"
-              ]
-            },
             "langs": {
               "type": "array",
               "maxLength": 3,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waverlyai/atproto-api",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "main": "src/index.ts",
   "scripts": {
     "codegen": "lex gen-api ./src/client ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/* ../../lexicons/social/waverly/*",

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -6462,15 +6462,6 @@ export const schemaDict = {
               type: 'ref',
               ref: 'lex:com.atproto.repo.strongRef',
             },
-            embed: {
-              type: 'union',
-              refs: [
-                'lex:app.bsky.embed.images',
-                'lex:app.bsky.embed.external',
-                'lex:app.bsky.embed.record',
-                'lex:app.bsky.embed.recordWithMedia',
-              ],
-            },
             langs: {
               type: 'array',
               maxLength: 3,

--- a/packages/api/src/client/types/social/waverly/miniblog.ts
+++ b/packages/api/src/client/types/social/waverly/miniblog.ts
@@ -7,21 +7,11 @@ import { lexicons } from '../../../lexicons'
 import { CID } from 'multiformats/cid'
 import * as AppBskyRichtextFacet from '../../app/bsky/richtext/facet'
 import * as ComAtprotoRepoStrongRef from '../../com/atproto/repo/strongRef'
-import * as AppBskyEmbedImages from '../../app/bsky/embed/images'
-import * as AppBskyEmbedExternal from '../../app/bsky/embed/external'
-import * as AppBskyEmbedRecord from '../../app/bsky/embed/record'
-import * as AppBskyEmbedRecordWithMedia from '../../app/bsky/embed/recordWithMedia'
 
 export interface Record {
   text: string
   facets?: AppBskyRichtextFacet.Main[]
   subject?: ComAtprotoRepoStrongRef.Main
-  embed?:
-    | AppBskyEmbedImages.Main
-    | AppBskyEmbedExternal.Main
-    | AppBskyEmbedRecord.Main
-    | AppBskyEmbedRecordWithMedia.Main
-    | { $type: string; [k: string]: unknown }
   langs?: string[]
   createdAt: string
   [k: string]: unknown

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -6462,15 +6462,6 @@ export const schemaDict = {
               type: 'ref',
               ref: 'lex:com.atproto.repo.strongRef',
             },
-            embed: {
-              type: 'union',
-              refs: [
-                'lex:app.bsky.embed.images',
-                'lex:app.bsky.embed.external',
-                'lex:app.bsky.embed.record',
-                'lex:app.bsky.embed.recordWithMedia',
-              ],
-            },
             langs: {
               type: 'array',
               maxLength: 3,

--- a/packages/pds/src/lexicon/types/social/waverly/miniblog.ts
+++ b/packages/pds/src/lexicon/types/social/waverly/miniblog.ts
@@ -7,21 +7,11 @@ import { isObj, hasProp } from '../../../util'
 import { CID } from 'multiformats/cid'
 import * as AppBskyRichtextFacet from '../../app/bsky/richtext/facet'
 import * as ComAtprotoRepoStrongRef from '../../com/atproto/repo/strongRef'
-import * as AppBskyEmbedImages from '../../app/bsky/embed/images'
-import * as AppBskyEmbedExternal from '../../app/bsky/embed/external'
-import * as AppBskyEmbedRecord from '../../app/bsky/embed/record'
-import * as AppBskyEmbedRecordWithMedia from '../../app/bsky/embed/recordWithMedia'
 
 export interface Record {
   text: string
   facets?: AppBskyRichtextFacet.Main[]
   subject?: ComAtprotoRepoStrongRef.Main
-  embed?:
-    | AppBskyEmbedImages.Main
-    | AppBskyEmbedExternal.Main
-    | AppBskyEmbedRecord.Main
-    | AppBskyEmbedRecordWithMedia.Main
-    | { $type: string; [k: string]: unknown }
   langs?: string[]
   createdAt: string
   [k: string]: unknown


### PR DESCRIPTION
Moving the embeds back in the bluesky post. The reason is that it's too hard for us to support embed in social.waverly.miniblog because we need to convert image blobs to image URLs and this is a service provided by the bsky client.